### PR TITLE
Search feature

### DIFF
--- a/cruds_adminlte/templates/cruds/list.html
+++ b/cruds_adminlte/templates/cruds/list.html
@@ -22,6 +22,23 @@
                 </div>
                 {% endif %}
                 <div class="box-body">
+ {% if search %}
+            <div class="row">
+                <form action="" method="get">
+
+<div class="col-lg-6">
+    <div class="input-group">
+      <input type="text" name="q" value="{{q}}" class="form-control" placeholder="{% trans 'Search for...' %}">
+      <span class="input-group-btn">
+        <button class="btn btn-default" type="submit">
+        <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+        </button>
+      </span>
+    </div><!-- /input-group -->
+  </div><!-- /.col-lg-6 -->               	
+                </form>
+</div> <br>
+{% endif %}
                     <table id="datatable" class="table table-bordered table-hover">
                     {% if object_list %}
                         <thead>

--- a/demo/testapp/views.py
+++ b/demo/testapp/views.py
@@ -47,8 +47,8 @@ class Lines_AjaxCRUD(InlineAjaxCRUD):
 
 class InvoiceCRUD(CRUDView):
     model = Invoice
-    check_login = True
-    check_perms = True
+    check_login = False
+    check_perms = False
     add_form = InvoiceForm
     update_form = InvoiceForm
     fields = ['customer', 'registered', 'sent', 'paid', 'date',
@@ -63,3 +63,5 @@ class InvoiceCRUD(CRUDView):
                       'total']
     inlines = [Lines_AjaxCRUD]
     views_available = ['create', 'list', 'detail']
+    search_fields = ['description1__icontains']
+    split_space_search = True

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -87,6 +87,23 @@ If check_perms = True we will add default django model perms  (<applabel>.[add|c
     applabel.view_model is used by default for list perm, so if it's not
     created then list view raise 503 permission denied (with screen in browser)
 
+Searching
+------------
+
+As django admin does **search_fields** are available, and you can filter using doble underscore (__) to search across objects.
+
+**split_space_search** split search text in parts using the string provided, this can be usefull to have better results but have impact in search performance, if split_space_search is True then ' ' is used
+
+.. code:: python
+
+    class Myclass(CRUDView):
+        model = Customer
+        search_fields = ['description__icontains']
+        split_space_search = ' ' # default False 
+
+.. note::  icontains is not set by default as django admin does, so you need to set if not equal search is wanted
+
+
 Overwrite forms
 -------------------
 


### PR DESCRIPTION
As django admin does **search_fields** are available, and you can filter using doble underscore (__) to search across objects.

**split_space_search** split search text in parts using the string provided, this can be usefull to have better results but have impact in search performance, if split_space_search is True then ' ' is used

```
    class Myclass(CRUDView):
        model = Customer
        search_fields = ['description__icontains']
        split_space_search = ' ' # default False 
```

NOTE: icontains is not set by default as django admin does, so you need to set if not equal search is wanted
