### PR TITLE
Support overriding blocks in CRUD views

### DIFF
--- a/cruds_adminlte/crud.py
+++ b/cruds_adminlte/crud.py
@@ -120,6 +120,7 @@ class CRUDMixin(object):
             'model_verbose_name_plural': self.model._meta.verbose_name_plural,
             'namespace': self.namespace
         })
+        context.update({'blocks': self.template_blocks})
 
         if self.view_type in ['update', 'detail']:
             context['inlines'] = self.inlines
@@ -282,6 +283,7 @@ class CRUDView(object):
 
     model = None
     template_name_base = "cruds"
+    template_blocks = {}
     namespace = None
     fields = '__all__'
     urlprefix = ""
@@ -353,6 +355,7 @@ class CRUDView(object):
             views_available = self.views_available[:]
             check_perms = self.check_perms
             template_father = self.template_father
+            template_blocks = self.template_blocks
             related_fields = self.related_fields
 
             def form_valid(self, form):
@@ -389,6 +392,7 @@ class CRUDView(object):
             views_available = self.views_available[:]
             check_perms = self.check_perms
             template_father = self.template_father
+            template_blocks = self.template_blocks
             related_fields = self.related_fields
 
             def get_success_url(self):
@@ -415,6 +419,7 @@ class CRUDView(object):
             views_available = self.views_available[:]
             check_perms = self.check_perms
             template_father = self.template_father
+            template_blocks = self.template_blocks
             related_fields = self.related_fields
 
             def form_valid(self, form):
@@ -451,6 +456,7 @@ class CRUDView(object):
             views_available = self.views_available[:]
             check_perms = self.check_perms
             template_father = self.template_father
+            template_blocks = self.template_blocks
             search_fields = self.search_fields
             split_space_search = self.split_space_search
             related_fields = self.related_fields
@@ -520,6 +526,7 @@ class CRUDView(object):
             views_available = self.views_available[:]
             check_perms = self.check_perms
             template_father = self.template_father
+            template_blocks = self.template_blocks
             related_fields = self.related_fields
 
             def get_success_url(self):

--- a/cruds_adminlte/templates/cruds/create.html
+++ b/cruds_adminlte/templates/cruds/create.html
@@ -1,10 +1,10 @@
 {% extends template_father %}
 {% load i18n %}
 
-{% block title %}{% trans "Create new" %} {{ model_verbose_name_plural|lower }}{% endblock %}
-{% block body_class %}{{ model_verbose_name_plural|lower }}{% endblock body_class %}
-{% block page_name %}{{ model_verbose_name_plural }}{% endblock %}
-{% block page_description %}{% trans "Create new" %} {{ model_verbose_name_plural|lower }}{% endblock %}
+{% block title %}{% if blocks.title %}{{ blocks.page_description }}{% else %}{% trans "Create new" %} {{ model_verbose_name_plural|lower }}{% endif %}{% endblock %}
+{% block body_class %}{{ blocks.body_class|default:model_verbose_name_plural|lower }}{% endblock body_class %}
+{% block page_name %}{{ blocks.page_name|default:model_verbose_name_plural }}{% endblock %}
+{% block page_description %}{% if blocks.page_description %}{{ blocks.page_description }}{% else %}{% trans "Create new" %} {{ model_verbose_name_plural|lower }}{% endif %}{% endblock %}
 
 {% block content %}
 <div class="row">

--- a/cruds_adminlte/templates/cruds/detail.html
+++ b/cruds_adminlte/templates/cruds/detail.html
@@ -1,10 +1,11 @@
 {% extends template_father %}
 {% load i18n %}
 {% load crud_tags %}
-{% block title %}{% trans "Detail of" %} {{ model_verbose_name|lower }}{% endblock %}
-{% block body_class %}{{ model_verbose_name_plural|lower }}{% endblock body_class %}
-{% block page_name %}{{ model_verbose_name_plural }}{% endblock %}
-{% block page_description %}{% trans "Detail of" %} {{ object }}{% endblock %}
+
+{% block title %}{% if blocks.title %}{{ blocks.page_description }}{% else %}{% trans "Detail of" %} {{ model_verbose_name|lower }}{% endif %}{% endblock %}
+{% block body_class %}{{ blocks.body_class|default:model_verbose_name_plural|lower }}{% endblock body_class %}
+{% block page_name %}{{ blocks.page_name|default:model_verbose_name_plural }}{% endblock %}
+{% block page_description %}{% if blocks.page_description %}{{ blocks.page_description }}{% else %}{% trans "Detail of" %} {{ object }}{% endif %}{% endblock %}
 
 
 {% block content %}

--- a/cruds_adminlte/templates/cruds/list.html
+++ b/cruds_adminlte/templates/cruds/list.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 {% load crud_tags %}
 
-{% block title %}{% trans "List of" %} {{ model_verbose_name_plural|lower }}{% endblock %}
-{% block body_class %}{{ model_verbose_name_plural|lower }}{% endblock body_class %}
-{% block page_name %}{{ model_verbose_name_plural }}{% endblock %}
-{% block page_description %}{% trans "List of" %} {{ model_verbose_name_plural|lower }}{% endblock %}
+{% block title %}{% if blocks.title %}{{ blocks.page_description }}{% else %}{% trans "List of" %} {{ model_verbose_name_plural|lower }}{% endif %}{% endblock %}
+{% block body_class %}{{ blocks.body_class|default:model_verbose_name_plural|lower }}{% endblock body_class %}
+{% block page_name %}{{ blocks.page_name|default:model_verbose_name_plural }}{% endblock %}
+{% block page_description %}{% if blocks.page_description %}{{ blocks.page_description }}{% else %}{% trans "List of" %} {{ model_verbose_name_plural|lower }}{% endif %}{% endblock %}
 
 
 {% block content %}

--- a/cruds_adminlte/templates/cruds/update.html
+++ b/cruds_adminlte/templates/cruds/update.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 {% load crud_tags %}
 
-{% block title %}{% trans "Update" %} {{ model_verbose_name_plural|lower }}{% endblock %}
-{% block body_class %}{{ model_verbose_name_plural|lower }}{% endblock body_class %}
-{% block page_name %}{{ model_verbose_name_plural }}{% endblock %}
-{% block page_description %}{% trans "Update" %} {{ model_verbose_name_plural|lower }}{% endblock %}
+{% block title %}{% if blocks.title %}{{ blocks.page_description }}{% else %}{% trans "Update" %} {{ model_verbose_name_plural|lower }}{% endif %}{% endblock %}
+{% block body_class %}{{ blocks.body_class|default:model_verbose_name_plural|lower }}{% endblock body_class %}
+{% block page_name %}{{ blocks.page_name|default:model_verbose_name_plural }}{% endblock %}
+{% block page_description %}{% if blocks.page_description %}{{ blocks.page_description }}{% else %}{% trans "Update" %} {{ model_verbose_name_plural|lower }}{% endif %}{% endblock %}
 
 {% block content %}
 <div class="row">


### PR DESCRIPTION
Hi,

This PR allows users to quickly change any block in a template without having to overwrite the whole template. For example, if you'd like to change the page title, name and description, you just need to set:
```
from cruds_adminlte.crud import CRUDView
from django.utils.translation import ugettext_lazy as _

class MyView(CRUDView):
    from .models import MyModel
    model = MyModel
    template_blocks = {'title': _('My fancy page title'),
                       'page_name': _('Some results'),
                       'page_description': _('Details')}
```
