### PR TITLE
Support fields from related models in CRUD views

### DIFF
--- a/cruds_adminlte/templatetags/crud_tags.py
+++ b/cruds_adminlte/templatetags/crud_tags.py
@@ -67,6 +67,9 @@ def format_value(obj, field_name):
 
     If value is model instance returns link to detail view if exists.
     """
+    if '__' in field_name:
+        related_model, field_name = field_name.split('__', maxsplit=1)
+        obj = getattr(obj, related_model)
     display_func = getattr(obj, 'get_%s_display' % field_name, None)
     if display_func:
         return display_func()


### PR DESCRIPTION
Hi,

This PR adds the possiblity to have fields from related models in CRUD views. For example, you can then have
```
from cruds_adminlte.crud import CRUDView

class MyView(CRUDView):
    from .models import MyModel
    model = MyModel
    list_fields =  ['my_related_field__related_model_field',]
```

where for example
```
from django.db import models

class MyOtherModel(models.Model):
    related_model_field = models.CharField(max_length=...)

class MyModel(models.Model):
    my_related_field = models.OneToOneField(MyOtherModel, on_delete=...)
```

where the `__` (double underscore) allows you to look for a field `related_model_field` from a related model via `my_related_field`.