### PR TITLE
 django-ajax fixed to point to the right min.js file

### DIFF
--- a/cruds_adminlte/templates/cruds/base.html
+++ b/cruds_adminlte/templates/cruds/base.html
@@ -23,9 +23,8 @@
     {% block javascript %}
         {% include 'adminlte/lib/_scripts.html' %}
         <script type="text/javascript" src="{% static 'jquery-cookie/jquery.cookie.js' %}"></script>
-<script type="text/javascript" src="{% static 'django_ajax/js/jquery.ajax.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'django_ajax/js/jquery.ajax-plugin.js' %}"></script>
-
+        <script type="text/javascript" src="{% static 'django_ajax/js/jquery.ajax.min.js' %}"></script>
+        <script type="text/javascript" src="{% static 'django_ajax/js/jquery.ajax-plugin.min.js' %}"></script>
     {% endblock %}
     {% block js %}{% endblock js %}
 


### PR DESCRIPTION
JQuery AJAX plugin was not loaded because the filename was mistaken.