### PR TITLE
Changes to setup.py version

### DIFF
--- a/cruds_adminlte/urls.py
+++ b/cruds_adminlte/urls.py
@@ -45,7 +45,9 @@ def crud_for_model(model, urlprefix=None, namespace=None,
         cruds_url = mycruds_url
         list_fields = mylist_fields
         related_fields = myrelated_fields
-        mixin = mymixin
+        # mixin = mymixin  # @FIXME TypeError: metaclass conflict: the metaclass
+        # of a derived class must be a (non-strict) subclass of the metaclasses
+        # of all its bases
 
     nc = NOCLASS()
     return nc.get_urls()

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@
 
 import os
 import sys
+from codecs import open
+import subprocess
+
 
 try:
     from setuptools import setup
@@ -12,12 +15,19 @@ except ImportError:
 version = open('VERSION').read().replace('\n', '')
 readme = open('README.rst').read()
 
+
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist')
     print("You probably want to also tag the version now:")
     print("  git tag -a %s -m 'version %s'" % (version, version))
     print("  git push --tags")
     sys.exit()
+else:
+    if os.path.exists(os.path.join(os.path.dirname(__file__), '.git')):
+        cmd = 'git rev-parse --verify --short HEAD'.split(' ')
+        git_hash = subprocess.check_output(cmd).decode().replace('\n', '')
+        version = "%s+git.%s" % (version, git_hash)
+
 
 setup(
     name='django-cruds-adminlte',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = open('VERSION').read()
+version = open('VERSION').read().replace('\n', '')
 readme = open('README.rst').read()
 
 if sys.argv[-1] == 'publish':


### PR DESCRIPTION
Hi,

There are two commits here:
- b30765b removes the blank line of the VERSION file when it is read (prevents a final "-" on build files). This one should be merged
- 6664f0c will append the current git commit to the version number allowing to manage snapshot builds. This addendum is not done when doing a 'publish' to not disrupt release workflows.

ie: django-cruds-adminlte-0.0.16+git.8ffd335

marc