### PR TITLE
Add getparams for search parameters

### DIFF
--- a/cruds_adminlte/crud.py
+++ b/cruds_adminlte/crud.py
@@ -46,6 +46,10 @@ class CRUDMixin(object):
             context['search'] = False
         if self.view_type == 'list' and 'q' in self.request.GET:
             context['q'] = self.request.GET.get('q', '')
+            
+            if self.getparams:
+                self.getparams += "&"
+            self.getparams += "q=" + context['q']
 
     def get_filters(self, context):
         filter_params = []


### PR DESCRIPTION
Fix paginator bug: cannot navigate to other pages when searching

How to reproduce:
1- Add keywords into search fields and make a search (with more than one page result)
2- Try to go to page 2-3, this doesn't keep the search filter, so you can't see the other search pages